### PR TITLE
Task/update to 0.21.0 (#81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Atlas Android
 
+## 0.2.10
+
+### Major Changes
+  * Updated to Layer Android SDK Version 0.21.0
+  * Removed `Util.waitForContent` as that is now supported in the Layer SDK
+
+### Features
+  * Allowing customization of attachment menu background via `attachmentSendersBackground`
+
+## 0.2.9
+
+### Major Changes
+  * Updated to Layer Android SDK Version 0.20.4
+
 ## 0.2.8
 
 ### Major Changes

--- a/layer-atlas/build.gradle
+++ b/layer-atlas/build.gradle
@@ -28,7 +28,7 @@ repositories {
 
 dependencies {
     // Layer SDK
-    compile('com.layer.sdk:layer-sdk:0.20.4') {
+    compile('com.layer.sdk:layer-sdk:0.21.0') {
         exclude group: 'com.google.android.gms', module: 'play-services-gcm'
     }
     compile 'org.slf4j:slf4j-nop:1.7.2'

--- a/layer-atlas/src/main/java/com/layer/atlas/adapters/AtlasConversationsAdapter.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/adapters/AtlasConversationsAdapter.java
@@ -49,8 +49,8 @@ public class AtlasConversationsAdapter extends RecyclerView.Adapter<AtlasConvers
                 /* Only show conversations we're still a member of */
                 .predicate(new Predicate(Conversation.Property.PARTICIPANT_COUNT, Predicate.Operator.GREATER_THAN, 1))
 
-                /* Sort by the last Message's sentAt time */
-                .sortDescriptor(new SortDescriptor(Conversation.Property.LAST_MESSAGE_SENT_AT, SortDescriptor.Order.DESCENDING))
+                /* Sort by the last Message's receivedAt time */
+                .sortDescriptor(new SortDescriptor(Conversation.Property.LAST_MESSAGE_RECEIVED_AT, SortDescriptor.Order.DESCENDING))
                 .build();
         mQueryController = client.newRecyclerViewController(query, updateAttributes, this);
         mLayerClient = client;
@@ -165,10 +165,10 @@ public class AtlasConversationsAdapter extends RecyclerView.Adapter<AtlasConvers
             viewHolder.mTimeView.setText(null);
         } else {
             viewHolder.mMessageView.setText(Util.getLastMessageString(context, lastMessage));
-            if (lastMessage.getSentAt() == null) {
+            if (lastMessage.getReceivedAt() == null) {
                 viewHolder.mTimeView.setText(null);
             } else {
-                viewHolder.mTimeView.setText(Util.formatTime(context, lastMessage.getSentAt(), mTimeFormat, mDateFormat));
+                viewHolder.mTimeView.setText(Util.formatTime(context, lastMessage.getReceivedAt(), mTimeFormat, mDateFormat));
             }
         }
     }

--- a/layer-atlas/src/main/java/com/layer/atlas/adapters/AtlasMessagesAdapter.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/adapters/AtlasMessagesAdapter.java
@@ -281,11 +281,11 @@ public class AtlasMessagesAdapter extends RecyclerView.Adapter<AtlasMessagesAdap
             viewHolder.mTimeGroup.setVisibility(View.GONE);
         } else if (cluster.mDateBoundaryWithPrevious || cluster.mClusterWithPrevious == ClusterType.MORE_THAN_HOUR) {
             // Crossed into a new day, or > 1hr lull in conversation
-            Date sentAt = message.getSentAt();
-            if (sentAt == null) sentAt = new Date();
-            String timeBarDayText = Util.formatTimeDay(viewHolder.mCell.getContext(), sentAt);
+            Date receivedAt = message.getReceivedAt();
+            if (receivedAt == null) receivedAt = new Date();
+            String timeBarDayText = Util.formatTimeDay(viewHolder.mCell.getContext(), receivedAt);
             viewHolder.mTimeGroupDay.setText(timeBarDayText);
-            String timeBarTimeText = mTimeFormat.format(sentAt.getTime());
+            String timeBarTimeText = mTimeFormat.format(receivedAt.getTime());
             viewHolder.mTimeGroupTime.setText(" " + timeBarTimeText);
             viewHolder.mTimeGroup.setVisibility(View.VISIBLE);
             viewHolder.mClusterSpaceGap.setVisibility(View.GONE);
@@ -416,7 +416,7 @@ public class AtlasMessagesAdapter extends RecyclerView.Adapter<AtlasMessagesAdap
         int previousPosition = position - 1;
         Message previousMessage = (previousPosition >= 0) ? getItem(previousPosition) : null;
         if (previousMessage != null) {
-            result.mDateBoundaryWithPrevious = isDateBoundary(previousMessage.getSentAt(), message.getSentAt());
+            result.mDateBoundaryWithPrevious = isDateBoundary(previousMessage.getReceivedAt(), message.getReceivedAt());
             result.mClusterWithPrevious = ClusterType.fromMessages(previousMessage, message);
 
             Cluster previousCluster = mClusterCache.get(previousMessage.getId());
@@ -437,7 +437,7 @@ public class AtlasMessagesAdapter extends RecyclerView.Adapter<AtlasMessagesAdap
         int nextPosition = position + 1;
         Message nextMessage = (nextPosition < getItemCount()) ? getItem(nextPosition) : null;
         if (nextMessage != null) {
-            result.mDateBoundaryWithNext = isDateBoundary(message.getSentAt(), nextMessage.getSentAt());
+            result.mDateBoundaryWithNext = isDateBoundary(message.getReceivedAt(), nextMessage.getReceivedAt());
             result.mClusterWithNext = ClusterType.fromMessages(message, nextMessage);
 
             Cluster nextCluster = mClusterCache.get(nextMessage.getId());
@@ -657,10 +657,10 @@ public class AtlasMessagesAdapter extends RecyclerView.Adapter<AtlasMessagesAdap
             if (!older.getSender().equals(newer.getSender())) return NEW_SENDER;
 
             // Time clustering for same user?
-            Date oldSentAt = older.getSentAt();
-            Date newSentAt = newer.getSentAt();
-            if (oldSentAt == null || newSentAt == null) return LESS_THAN_MINUTE;
-            long delta = Math.abs(newSentAt.getTime() - oldSentAt.getTime());
+            Date oldReceivedAt = older.getReceivedAt();
+            Date newReceivedAt = newer.getReceivedAt();
+            if (oldReceivedAt == null || newReceivedAt == null) return LESS_THAN_MINUTE;
+            long delta = Math.abs(newReceivedAt.getTime() - oldReceivedAt.getTime());
             if (delta <= MILLIS_MINUTE) return LESS_THAN_MINUTE;
             if (delta <= MILLIS_HOUR) return LESS_THAN_HOUR;
             return MORE_THAN_HOUR;

--- a/layer-atlas/src/main/java/com/layer/atlas/messagetypes/location/LocationSender.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/messagetypes/location/LocationSender.java
@@ -24,6 +24,7 @@ import com.layer.sdk.LayerClient;
 import com.layer.sdk.messaging.Message;
 import com.layer.sdk.messaging.MessageOptions;
 import com.layer.sdk.messaging.MessagePart;
+import com.layer.sdk.messaging.PushNotificationPayload;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -170,7 +171,10 @@ public class LocationSender extends AttachmentSender {
                         .put(LocationCellFactory.KEY_LABEL, myName);
                 String notification = context.getString(R.string.atlas_notification_location, myName);
                 MessagePart part = client.newMessagePart(LocationCellFactory.MIME_TYPE, o.toString().getBytes());
-                Message message = client.newMessage(new MessageOptions().pushNotificationMessage(notification), part);
+                PushNotificationPayload payload = new PushNotificationPayload.Builder()
+                        .text(notification)
+                        .build();
+                Message message = client.newMessage(new MessageOptions().defaultPushNotificationPayload(payload), part);
                 sender.send(message);
             } catch (JSONException e) {
                 if (Log.isLoggable(Log.ERROR)) {

--- a/layer-atlas/src/main/java/com/layer/atlas/messagetypes/text/TextSender.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/messagetypes/text/TextSender.java
@@ -6,6 +6,7 @@ import com.layer.atlas.util.Log;
 import com.layer.sdk.messaging.Message;
 import com.layer.sdk.messaging.MessageOptions;
 import com.layer.sdk.messaging.MessagePart;
+import com.layer.sdk.messaging.PushNotificationPayload;
 
 public class TextSender extends MessageSender {
     private final int mMaxNotificationLength;
@@ -31,7 +32,10 @@ public class TextSender extends MessageSender {
 
         // Send message
         MessagePart part = getLayerClient().newMessagePart(text);
-        Message message = getLayerClient().newMessage(new MessageOptions().pushNotificationMessage(notificationString), part);
+        PushNotificationPayload payload = new PushNotificationPayload.Builder()
+                .text(notificationString)
+                .build();
+        Message message = getLayerClient().newMessage(new MessageOptions().defaultPushNotificationPayload(payload), part);
         return send(message);
     }
 }

--- a/layer-atlas/src/main/java/com/layer/atlas/messagetypes/threepartimage/CameraSender.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/messagetypes/threepartimage/CameraSender.java
@@ -11,6 +11,7 @@ import com.layer.atlas.R;
 import com.layer.atlas.messagetypes.AttachmentSender;
 import com.layer.atlas.util.Log;
 import com.layer.sdk.messaging.Message;
+import com.layer.sdk.messaging.PushNotificationPayload;
 
 import java.io.File;
 import java.io.IOException;
@@ -72,7 +73,11 @@ public class CameraSender extends AttachmentSender {
         try {
             String myName = getParticipantProvider().getParticipant(getLayerClient().getAuthenticatedUserId()).getName();
             Message message = ThreePartImageUtils.newThreePartImageMessage(activity, getLayerClient(), new File(mPhotoFilePath.get()));
-            message.getOptions().pushNotificationMessage(getContext().getString(R.string.atlas_notification_image, myName));
+
+            PushNotificationPayload payload = new PushNotificationPayload.Builder()
+                    .text(getContext().getString(R.string.atlas_notification_image, myName))
+                    .build();
+            message.getOptions().defaultPushNotificationPayload(payload);
             send(message);
         } catch (IOException e) {
             if (Log.isLoggable(Log.ERROR)) Log.e(e.getMessage(), e);

--- a/layer-atlas/src/main/java/com/layer/atlas/messagetypes/threepartimage/GallerySender.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/messagetypes/threepartimage/GallerySender.java
@@ -11,6 +11,7 @@ import com.layer.atlas.R;
 import com.layer.atlas.messagetypes.AttachmentSender;
 import com.layer.atlas.util.Log;
 import com.layer.sdk.messaging.Message;
+import com.layer.sdk.messaging.PushNotificationPayload;
 
 import java.io.IOException;
 import java.lang.ref.WeakReference;
@@ -80,7 +81,11 @@ public class GallerySender extends AttachmentSender {
         try {
             String myName = getParticipantProvider().getParticipant(getLayerClient().getAuthenticatedUserId()).getName();
             Message message = ThreePartImageUtils.newThreePartImageMessage(activity, getLayerClient(), data.getData());
-            message.getOptions().pushNotificationMessage(getContext().getString(R.string.atlas_notification_image, myName));
+
+            PushNotificationPayload payload = new PushNotificationPayload.Builder()
+                    .text(getContext().getString(R.string.atlas_notification_image, myName))
+                    .build();
+            message.getOptions().defaultPushNotificationPayload(payload);
             send(message);
         } catch (IOException e) {
             if (Log.isLoggable(Log.ERROR)) Log.e(e.getMessage(), e);

--- a/layer-atlas/src/main/java/com/layer/atlas/util/Util.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/util/Util.java
@@ -30,11 +30,8 @@ import com.layer.atlas.messagetypes.threepartimage.ThreePartImageCellFactory;
 import com.layer.atlas.provider.Participant;
 import com.layer.atlas.provider.ParticipantProvider;
 import com.layer.sdk.LayerClient;
-import com.layer.sdk.changes.LayerChange;
-import com.layer.sdk.changes.LayerChangeEvent;
 import com.layer.sdk.exceptions.LayerException;
 import com.layer.sdk.listeners.LayerAuthenticationListener;
-import com.layer.sdk.listeners.LayerChangeEventListener;
 import com.layer.sdk.listeners.LayerProgressListener;
 import com.layer.sdk.messaging.Conversation;
 import com.layer.sdk.messaging.Message;
@@ -227,64 +224,6 @@ public class Util {
             }
         }
         return new int[]{scaledWidth, scaledHeight};
-    }
-
-    /**
-     * Asynchronously waits for the LayerClient to synchronize relevant data before calling the
-     * given Callback.
-     * TODO: add timeout mechanism.
-     *
-     * @param client   LayerClient to await content for.
-     * @param id       Queryable object ID to wait for (Conversation, Message, MessagePart, etc).
-     * @param callback ContentAvailableCallback to alert success or failure.
-     */
-    public static void waitForContent(final LayerClient client, final Uri id, final ContentAvailableCallback callback) {
-        if (client == null) {
-            callback.onContentFailed(client, id, "LayerClient is null");
-            return;
-        }
-
-        if (id == null) {
-            callback.onContentFailed(client, id, "LayerObject ID is null");
-            return;
-        }
-
-        // Register an event listener that waits for the given conversation or message
-        final AtomicBoolean hasNotified = new AtomicBoolean(false);
-        LayerChangeEventListener listener = new LayerChangeEventListener.BackgroundThread() {
-            @Override
-            public void onChangeEvent(LayerChangeEvent layerChangeEvent) {
-                for (LayerChange change : layerChangeEvent.getChanges()) {
-                    Queryable q = (Queryable) change.getObject();
-                    if (!q.getId().equals(id)) continue;
-                    client.unregisterEventListener(this);
-                    if (!hasNotified.compareAndSet(false, true)) return;
-                    if (Log.isLoggable(Log.VERBOSE)) {
-                        Log.v("Received content for " + id);
-                    }
-                    callback.onContentAvailable(client, q);
-                    return;
-                }
-            }
-        };
-        client.registerEventListener(listener);
-
-        // If content is not yet available, wait for the listener.
-        Queryable q = client.get(id);
-        if (q == null) {
-            if (Log.isLoggable(Log.VERBOSE)) {
-                Log.v("Content not yet available, waiting for " + id);
-            }
-            return;
-        }
-
-        // If content is available now, abort the listener and notify now.
-        client.unregisterEventListener(listener);
-        if (!hasNotified.compareAndSet(false, true)) return;
-        if (Log.isLoggable(Log.VERBOSE)) {
-            Log.v("Content already available for " + id);
-        }
-        callback.onContentAvailable(client, q);
     }
 
     /**

--- a/layer-atlas/version.gradle
+++ b/layer-atlas/version.gradle
@@ -1,1 +1,1 @@
-version = '0.2.8'
+version = '0.2.10'


### PR DESCRIPTION
* Use message's receivedAt for sorting, clustering and displaying timestamps on conversations and messages.

Atlas used last message's sentAt for sorting conversations, clustering messages and showing timestamps. But sentAt is not set on a message until it is synced to server. So, this is absent in UI when offline, conversations are not in correct sorted order, and messages are not clustered properly.

With 0.20.5, layer sdk sets receivedAt to reflect the time the message was received by this user. So, when an user sends a message, it will have the current device timestamp on it. On receivers side, it will have the timestamp the message reached the server (and hence the user's inbox). This change allows UI to use receivedAt for sorting, clustering and displaying timestamp's everywhere and makes the user experience better.

* Updating Layer SDK to 0.21.0.

Using new PushNotificationPayload object

* Removing `waitForContent()` as that is now supported by Layer SDK

* Preparing 0.2.9 release

* Preparing 0.2.10 release